### PR TITLE
fix: template use for Sentinel Repository aka CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# 🦜ParrotForce 
-Azure playbook for automatic evidence collection
+# 🦜ParrotForce
+Azure playbook for automatic evidence collection.
+
+Current playbook only includes MDE live response for Windows systems.
 
 ## Prerequisites
 ParrotForce uses connections to Azure Sentinel and Microsoft 365 Defender to function. The following API permissions need to be present in your managed identity that connects to Azure Sentinel and Microsoft 365 Defender:
-- AdvancedQuery.Read.All 
-- Alert.Read.All 
-- File.Read.All 
-- Machine.CollectForensics 
+- AdvancedQuery.Read.All
+- Alert.Read.All
+- File.Read.All
+- Machine.CollectForensics
 - Machine.LiveResponse
 
-By default, the Logic App of the template is configured on “Consumption” plan type, hence pricing will only occur upon workflow execution. 
+By default, the Logic App of the template is configured on “Consumption” plan type, hence pricing will only occur upon workflow execution.
 
 ## Quick Deployment
 Click on the button to deploy automatically to your Azure Subscription
@@ -23,3 +25,11 @@ Click on the button to deploy automatically to your Azure Subscription
 4. Click `Load File` and select the `deployazure.json` file to deploy ParrotForce
 5. Click Save and assign ParrotForce to your Resource Group and Subscription of your choice.
 
+## Sentinel Repository (CI/CD)
+1. Add folder to your repository
+2. Revalidate all connections, Sentinel, MDATP for all corresponding blocks. It's advised to use managed identity as much as possible.
+
+## All deployments
+1. Upload needed files inside MDATP/MDE library (typically make a live response session). By default: trident.ps1, winpmem.exe.
+  * https://github.com/nov3mb3r/trident (ps1 not signed by default)
+  * https://github.com/Velocidex/WinPmem

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,27 +1,116 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-        "workflows_ParrotForce_name": {
-            "defaultValue": "ParrotForce",
-            "type": "String"
+    "metadata": {
+        "title": "FalconForceTeam ParrotForce",
+        "description": "Azure playbook for automatic evidence collection.",
+        "mainSteps": [
+            "When... and depending on tags",
+            "1. Fetches the device information from MDE/MDATP",
+            "2. Get Investigation package or run live response script"
+        ],
+        "prerequisites": [
+            "Sentinel Responder role and some MDE/MDATP permissions are required."
+        ],
+        "entities": [
+            "Host"
+        ],
+        "tags": [
+            "Investigation"
+        ],
+        "support": {
+            "tier": "community"
         },
-        "connections_azuresentinel_1_externalid": {
-            "defaultValue": "/subscriptions/80110e3c-3ec4-4567-b06d-7d47a72562f5/resourceGroups/ResponseOps/providers/Microsoft.Web/connections/azuresentinel-1",
-            "type": "String"
+        "author": {
+            "name": "FalconForceTeam"
         },
-        "connections_wdatp_externalid": {
-            "defaultValue": "/subscriptions/80110e3c-3ec4-4567-b06d-7d47a72562f5/resourceGroups/ResponseOps/providers/Microsoft.Web/connections/wdatp",
-            "type": "String"
+        "source": {
+            "name": "FalconForceTeam",
+            "kind": "Community"
         }
     },
-    "variables": {},
+    "parameters": {
+        "resourceTags": {
+            "type": "object",
+            "defaultValue": {
+                "LogicAppsCategory": "security"
+            },
+            "metadata": {
+                "description": "The Azure tags to set on the resource."
+            }
+        },
+        "PlaybookName": {
+            "defaultValue": "ParrotForce",
+            "type": "string",
+            "metadata": {
+                "description": "The Playbook name."
+            }
+        },
+        "UserName": {
+            "defaultValue": "<username>@<domain>",
+            "type": "string",
+            "metadata": {
+                "description": "Username placeholder."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        }
+    },
+    "variables": {
+        "WDATPConnection": "[concat('Wdatp-', parameters('PlaybookName'))]",
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]"
+    },
     "resources": [
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('WDATPConnection')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
+            "comments": "This is the MDE/WDATP connection.",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location'), '/managedApis/azuread')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
+            "comments": "This is the Microsoft Sentinel connection.",
+            "properties": {
+                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "customParameterValues": {},
+                "parameterValueType": "Alternative",
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location'), '/managedApis/azuresentinel')]"
+                }
+            }
+        },
         {
             "type": "Microsoft.Logic/workflows",
             "apiVersion": "2017-07-01",
-            "name": "[parameters('workflows_ParrotForce_name')]",
-            "location": "westeurope",
+            "name": "[parameters('PlaybookName')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
+            "comments": "This is the playbook/logicapp.",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                "[resourceId('Microsoft.Web/connections', variables('WDATPConnection'))]"
+            ],
             "properties": {
                 "state": "Enabled",
                 "definition": {
@@ -406,14 +495,19 @@
                     "$connections": {
                         "value": {
                             "azuresentinel": {
-                                "connectionId": "[parameters('connections_azuresentinel_1_externalid')]",
-                                "connectionName": "azuresentinel-1",
-                                "id": "/subscriptions/80110e3c-3ec4-4567-b06d-7d47a72562f5/providers/Microsoft.Web/locations/westeurope/managedApis/azuresentinel"
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                "connectionName": "[variables('AzureSentinelConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location'), '/managedApis/azuresentinel')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             },
                             "wdatp": {
-                                "connectionId": "[parameters('connections_wdatp_externalid')]",
-                                "connectionName": "wdatp",
-                                "id": "/subscriptions/80110e3c-3ec4-4567-b06d-7d47a72562f5/providers/Microsoft.Web/locations/westeurope/managedApis/wdatp"
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('WDATPConnection'))]",
+                                "connectionName": "[variables('WDATPConnection')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location'), '/managedApis/wdatp')]"
                             }
                         }
                     }


### PR DESCRIPTION

* metadata: review how you feel appropriate, mostly in case you want to
  submit to Azure/Azure-Sentinel and documentation purpose
* add parameters for resourceTags, location, username
* remove hardcoded references to sentinel and MDE/wdatp connection

docs: review formatting, deployment
* pre-commit: end-of-line
* Sentinel Repository deployment, MDE live response library upload

With those changes, template can deploy through Sentinel Repository. Still have functional validation to make.